### PR TITLE
Useless parentheses around expressions should be removed

### DIFF
--- a/libraries/facebook/src/com/facebook/AppEventsLogger.java
+++ b/libraries/facebook/src/com/facebook/AppEventsLogger.java
@@ -261,7 +261,7 @@ public class AppEventsLogger {
             throw new IllegalArgumentException("Both context and applicationId must be non-null");
         }
 
-        if ((context instanceof Activity)) {
+        if (context instanceof Activity) {
             setSourceApplication((Activity) context);
         } else {
           // If context is not an Activity, we cannot get intent nor calling activity.

--- a/src/main/java/zame/game/Common.java
+++ b/src/main/java/zame/game/Common.java
@@ -136,18 +136,18 @@ public class Common {
 	public static void safeRename(String tmpName, String fileName) {
 		String oldName = fileName + ".old";
 
-		if ((new File(oldName)).exists()) {
-			(new File(oldName)).delete();
+		if (new File(oldName).exists()) {
+			new File(oldName).delete();
 		}
 
-		if ((new File(fileName)).exists()) {
-			(new File(fileName)).renameTo(new File(oldName));
+		if (new File(fileName).exists()) {
+			new File(fileName).renameTo(new File(oldName));
 		}
 
-		(new File(tmpName)).renameTo(new File(fileName));
+		new File(tmpName).renameTo(new File(fileName));
 
-		if ((new File(oldName)).exists()) {
-			(new File(oldName)).delete();
+		if (new File(oldName).exists()) {
+			new File(oldName).delete();
 		}
 	}
 
@@ -216,7 +216,7 @@ public class Common {
 			slotFileNames.clear();
 		}
 
-		String[] files = (new File(MyApplication.self.SAVES_FOLDER)).list();
+		String[] files = new File(MyApplication.self.SAVES_FOLDER).list();
 
 		if (files == null) {
 			return 0;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:UselessParenthesesCheck - “ Useless parentheses around expressions should be removed to prevent any misunderstanding ”. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
Please let me know if you have any questions.
Ayman Abdelghany.
