### PR TITLE
Deprecated elements should have both the annotation and the Javadoc tag

### DIFF
--- a/libraries/facebook/src/com/facebook/AppEventsLogger.java
+++ b/libraries/facebook/src/com/facebook/AppEventsLogger.java
@@ -220,6 +220,7 @@ public class AppEventsLogger {
 
     /**
      * This method is deprecated.  Use {@link Settings#getLimitEventAndDataUsage(Context)} instead.
+     * @deprecated Kept for backward compatibility
      */
     @Deprecated
     public static boolean getLimitEventUsage(Context context) {
@@ -228,6 +229,7 @@ public class AppEventsLogger {
 
     /**
      * This method is deprecated.  Use {@link Settings#setLimitEventAndDataUsage(Context, boolean)} instead.
+     * @deprecated Kept for backward compatibility
      */
     @Deprecated
     public static void setLimitEventUsage(Context context, boolean limitEventUsage) {

--- a/libraries/facebook/src/com/facebook/AppLinkData.java
+++ b/libraries/facebook/src/com/facebook/AppLinkData.java
@@ -368,6 +368,7 @@ public class AppLinkData {
 
     /**
      * This method has been deprecated. Please use {@link AppLinkData#getArgumentBundle()} instead.
+     * @deprecated Kept for backward compatibility
      * @return JSONObject property bag.
      */
     @Deprecated

--- a/libraries/facebook/src/com/facebook/InsightsLogger.java
+++ b/libraries/facebook/src/com/facebook/InsightsLogger.java
@@ -24,6 +24,7 @@ import java.math.BigDecimal;
 import java.util.Currency;
 
 /**
+ * @deprecated Kept for backward compatibility
  * This class is deprecated. Please use {@link AppEventsLogger} instead.
  */
 @Deprecated

--- a/libraries/facebook/src/com/facebook/Settings.java
+++ b/libraries/facebook/src/com/facebook/Settings.java
@@ -315,6 +315,7 @@ public final class Settings {
     /**
      * Sets whether opening a Session should automatically publish install attribution to the Facebook graph.
      *
+     * @deprecated Kept for backward compatibility
      * @param shouldAutoPublishInstall true to automatically publish, false to not
      *
      * This method is deprecated.  See {@link AppEventsLogger#activateApp(Context, String)} for more info.
@@ -327,6 +328,7 @@ public final class Settings {
     /**
      * Gets whether opening a Session should automatically publish install attribution to the Facebook graph.
      *
+     * @deprecated Kept for backward compatibility
      * @return true to automatically publish, false to not
      *
      * This method is deprecated.  See {@link AppEventsLogger#activateApp(Context, String)} for more info.

--- a/libraries/facebook/src/com/facebook/android/AsyncFacebookRunner.java
+++ b/libraries/facebook/src/com/facebook/android/AsyncFacebookRunner.java
@@ -67,6 +67,7 @@ public class AsyncFacebookRunner {
      * <p/>
      * This method is deprecated.  See {@link Facebook} and {@link com.facebook.Session} for more info.
      *
+     * @deprecated Kept for backward compatibility
      * @param context
      *            The Android context in which the logout should be called: it
      *            should be the same context in which the login occurred in
@@ -129,6 +130,7 @@ public class AsyncFacebookRunner {
      * <p/>
      * This method is deprecated.  See {@link Facebook} and {@link com.facebook.Request} for more info.
      *
+     * @deprecated Kept for backward compatibility
      * @param parameters
      *            Key-value pairs of parameters to the request. Refer to the
      *            documentation: one of the parameters must be "method".
@@ -163,6 +165,7 @@ public class AsyncFacebookRunner {
      * <p/>
      * This method is deprecated.  See {@link Facebook} and {@link com.facebook.Request} for more info.
      *
+     * @deprecated Kept for backward compatibility
      * @param graphPath
      *            Path to resource in the Facebook graph, e.g., to fetch data
      *            about the currently logged authenticated user, provide "me",
@@ -199,6 +202,7 @@ public class AsyncFacebookRunner {
      * <p/>
      * This method is deprecated.  See {@link Facebook} and {@link com.facebook.Request} for more info.
      *
+     * @deprecated Kept for backward compatibility
      * @param graphPath
      *            Path to resource in the Facebook graph, e.g., to fetch data
      *            about the currently logged authenticated user, provide "me",
@@ -244,6 +248,7 @@ public class AsyncFacebookRunner {
      * <p/>
      * This method is deprecated.  See {@link Facebook} and {@link com.facebook.Request} for more info.
      *
+     * @deprecated Kept for backward compatibility
      * @param graphPath
      *            Path to resource in the Facebook graph, e.g., to fetch data
      *            about the currently logged authenticated user, provide "me",

--- a/libraries/facebook/src/com/facebook/android/Facebook.java
+++ b/libraries/facebook/src/com/facebook/android/Facebook.java
@@ -111,6 +111,7 @@ public class Facebook {
     /**
      * Constructor for Facebook object.
      * 
+     * @deprecated Kept for backward compatibility
      * @param appId
      *            Your Facebook application ID. Found at
      *            www.facebook.com/developers/apps.php.


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:MissingDeprecatedCheck - “ Deprecated elements should have both the annotation and the Javadoc tag ”. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:MissingDeprecatedCheck
Please let me know if you have any questions.
Ayman Abdelghany.
